### PR TITLE
Add capability of backend hatchery retrieval

### DIFF
--- a/grubtrak/src/Home.js
+++ b/grubtrak/src/Home.js
@@ -1,10 +1,12 @@
 import React, {useState} from "react";
 import Navbar from './components/Navbar/Navbar';
 import VNavbar from './components/VNavbar/VNavbar'
+import axios from 'axios';
 import "./Home.css";
 import Modal from './components/Modal.js';
 import GlobalStyle from "./globalStyles";
 import styled from "styled-components";
+import { MdQueryBuilder } from "react-icons/md";
 
 
 function Home() {

--- a/grubtrak/src/Login.js
+++ b/grubtrak/src/Login.js
@@ -31,7 +31,7 @@ function Signup() {
                 let user = usersArr[i];
                 if (user.username === login.username && user.password === login.password)  {
                     authenticated = true;
-                    myStorage.setItem('currentUser', user);
+                    myStorage.setItem('currentUser', JSON.stringify(user));
                     window.location = '/Home';
                 }
             }


### PR DESCRIPTION
Added a `axios.put`for frontend to use to add new hatchery to user's hatchery field.

*HOW TO USE:*
<img width="750" alt="Screen Shot 2021-10-15 at 3 58 03 PM" src="https://user-images.githubusercontent.com/55326674/137547235-1e18c536-1740-4d50-b5b0-6f5eb688d489.png">

^I hardcoded values here but you can access _id the same way; the hatchery fields would obviously be the values entered in the specified boxes...
*this also shouldn't go in the `openModal()` ... we just wanted to test it on a button and this one was easy to grab*
